### PR TITLE
Instance-specific send and recieve functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ test = true
 doctest = true
 bench = false
 doc = true
-edition = "2021"
 crate-type = ["lib"]
 
 [dependencies]
@@ -29,6 +28,7 @@ thiserror = "2"
 libffi = "3.0.0"
 tempfile = "3.3.0"
 embed-doc-image = "0.1.4"
+gag = "1.0.0"
 
 [dev-dependencies]
 cpal = "0.15.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,17 +25,17 @@ crate-type = ["lib"]
 [dependencies]
 libpd-sys = "0.3"
 thiserror = "2"
-libffi = "3.0.0"
+libffi = "4.1.0"
 tempfile = "3.3.0"
 embed-doc-image = "0.1.4"
 gag = "1.0.0"
 
 [dev-dependencies]
-cpal = "0.15.3"
+cpal = "0.16.0"
 sys-info = "0.9.1"
 nannou = "0.19"
 nannou_audio = "0.19"
-rand = "0.8.5"
+rand = "0.9.2"
 serial_test = "3"
 
 # For local development,

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -34,7 +34,7 @@ impl Atom {
                     a_type: libpd_sys::t_atomtype_A_FLOAT,
                     a_w: libpd_sys::word { w_float: 0.0 },
                 };
-                let p = &mut t_atom as *mut libpd_sys::t_atom;
+                let p = &raw mut t_atom;
                 unsafe {
                     libpd_sys::libpd_set_double(p, *value);
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum PdError {
     /// An error occurred during audio initialization.
     #[error(transparent)]
     AudioInitializationError(#[from] AudioInitializationError),
+    #[error(transparent)]
+    RecieveError(#[from] RecieveError),
     /// An error occurred during patch lifecycle.
     #[error(transparent)]
     PatchLifeCycleError(#[from] PatchLifeCycleError),
@@ -72,6 +74,15 @@ pub enum AudioInitializationError {
     /// A failure happened in pd audio initialization with an unknown reason.
     #[error("An unknown error occurred in Pure Data audio initialization.")]
     InitializationFailed,
+}
+
+/// Errors related to audio initialization.
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum RecieveError {
+    /// The DSP was active while registering the callback
+    #[error("Audio playback needs to be off when registering this callback.")]
+    DspActive,
 }
 
 /// Errors related to a lifecycle of a pd patch.
@@ -143,6 +154,12 @@ pub enum SendError {
     /// `CString` or `CStr` conversion error.
     #[error(transparent)]
     StringConversion(#[from] StringConversionError),
+    /// Data was added to a non-existant message.
+    #[error("Message must be started with start_message before adding to it.")]
+    MessageNotStarted,
+    /// Message was started while another message was already started.
+    #[error("Message must be submitted before starting a new message.")]
+    MessageAlreadyStarted,
 }
 
 /// Errors related to subscription to senders in a pd patch.

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -425,6 +425,10 @@ use std::{env, path};
 /// - [`RingBufferInitializationError`](crate::error::InitializationError::RingBufferInitializationError)
 /// - [`InitializationFailed`](crate::error::InitializationError::InitializationFailed)
 pub fn init() -> Result<(), InitializationError> {
+    // libpd prints a bunch of guff to stderr when loading, which is not desirable for a library
+    // so we try to prevent it from printing that info to stderr.
+    let _gag = gag::Gag::stderr();
+
     unsafe {
         match libpd_sys::libpd_queued_init() {
             // Returns -1 if it is already initialized which we ignore.
@@ -677,7 +681,7 @@ pub fn block_size() -> i32 {
 /// Initializes audio rendering
 ///
 /// This doesn't mean that the audio is actually playing.
-/// To start audio processing please call [`dsp_on`](crate::util::dsp_on) function after the initialization.
+/// To start audio processing please call [`dsp_on`](crate::functions::util::dsp_on) function after the initialization.
 ///
 /// # Errors
 ///

--- a/src/functions/gui.rs
+++ b/src/functions/gui.rs
@@ -49,7 +49,7 @@ pub fn stop_gui() {
 
 /// Manually updates and handles any GUI messages
 ///
-/// This is called automatically when running any process function in the library. e.g. [`process_float`](crate::process::process_float).
+/// This is called automatically when running any process function in the library. e.g. [`process_float`](crate::functions::process::process_float).
 ///
 /// Note:
 /// - This also facilitates network message processing, etc so it can be useful to call repeatedly when idle for more throughput.

--- a/src/functions/send.rs
+++ b/src/functions/send.rs
@@ -367,12 +367,12 @@ pub fn finish_message_as_typed_message_and_send_to<T: AsRef<str>, S: AsRef<str>>
 /// # Errors
 ///
 /// A list of errors that can occur:
-/// - [`SendError`](crate::error::SendError)
+/// - [`SendError`]
 ///    - [`MissingDestination`](crate::error::SendError::MissingDestination)
 ///    - [`StringConversion`](crate::error::SendError::StringConversion)
 /// - [`InstanceError`](crate::error::InstanceError)
 ///    - [`NoCurrentInstanceSet`](crate::error::InstanceError::NoCurrentInstanceSet)
-/// - [`PdError`](crate::error::PdError)
+/// - [`PdError`]
 ///    - [`StringConversion`](crate::error::PdError::StringConversion)
 pub fn send_list_to<T: AsRef<str>>(receiver: T, list: &[Atom]) -> Result<(), PdError> {
     let recv = CString::new(receiver.as_ref()).map_err(StringConversionError::from)?;
@@ -423,12 +423,12 @@ pub fn send_list_to<T: AsRef<str>>(receiver: T, list: &[Atom]) -> Result<(), PdE
 /// # Errors
 ///
 /// A list of errors that can occur:
-/// - [`SendError`](crate::error::SendError)
+/// - [`SendError`]
 ///    - [`MissingDestination`](crate::error::SendError::MissingDestination)
 ///    - [`StringConversion`](crate::error::SendError::StringConversion)
 /// - [`InstanceError`](crate::error::InstanceError)
 ///    - [`NoCurrentInstanceSet`](crate::error::InstanceError::NoCurrentInstanceSet)
-/// - [`PdError`](crate::error::PdError)
+/// - [`PdError`]
 ///    - [`StringConversion`](crate::error::PdError::StringConversion)
 pub fn send_message_to<T: AsRef<str>>(
     receiver: T,

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,18 +1,18 @@
 #![allow(clippy::restriction)]
 
-use libpd_rs::functions::{
-    array::{
+use libpd_rs::{
+    functions::array::{
         array_size, read_double_array_from, read_float_array_from, resize_array,
         write_double_array_to, write_float_array_to,
     },
-    close_patch,
+    Pd,
 };
 
 #[test]
 fn apply_array_operations_in_a_row() {
-    libpd_rs::functions::init().unwrap();
+    let mut pd = Pd::init_and_configure(0, 2, 44100).unwrap();
 
-    let handle = libpd_rs::functions::open_patch("tests/patches/array_sketch_pad.pd").unwrap();
+    pd.open_patch("tests/patches/array_sketch_pad.pd").unwrap();
 
     let bad_name = "not_exists";
     let sketch_pad = "sketch_pad";
@@ -116,5 +116,5 @@ fn apply_array_operations_in_a_row() {
     let result = read_float_array_from(sketch_pad, 0, -1, &mut read_to);
     assert!(result.is_err());
 
-    close_patch(handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/listening.rs
+++ b/tests/listening.rs
@@ -1,41 +1,38 @@
 #![allow(clippy::restriction)]
 #![allow(clippy::unnecessary_cast)]
 
-use libpd_rs::functions::{
-    close_patch, init, initialize_audio, open_patch,
-    receive::{source_to_listen_from_exists, start_listening_from, stop_listening_from},
-    util::dsp_on,
-};
 use libpd_rs::types::ReceiverHandle;
+use libpd_rs::Pd;
 
 #[test]
 fn listening() {
     let sample_rate = 44100;
     let output_channels = 2;
 
-    init().unwrap();
-    initialize_audio(0, output_channels, sample_rate).unwrap();
-    dsp_on().unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    pd.dsp_on().unwrap();
 
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
-    let result = start_listening_from("list_from_pd");
+    let result = pd.start_listening_from("list_from_pd");
     assert!(result.is_ok());
     // Just crates the endpoint.
-    let result = start_listening_from("non_existent");
+    let result = pd.start_listening_from("non_existent");
     assert!(result.is_ok());
 
-    let handle_1 = start_listening_from("list_from_pd").unwrap();
-    let handle_2 = start_listening_from("list_from_pd").unwrap();
+    let handle_1 = pd.start_listening_from("list_from_pd").unwrap();
+    let handle_2 = pd.start_listening_from("list_from_pd").unwrap();
 
-    stop_listening_from(handle_1);
-    stop_listening_from(handle_2);
+    pd.stop_listening_from(handle_1);
+    pd.stop_listening_from(handle_2);
     // It will just ignore the null pointer.
     let handle: ReceiverHandle = (std::ptr::null_mut() as *mut std::ffi::c_void).into();
-    stop_listening_from(handle);
+    pd.stop_listening_from(handle);
 
-    assert!(source_to_listen_from_exists("list_from_pd").unwrap());
-    assert!(!source_to_listen_from_exists("endpoint_not_created").unwrap());
+    assert!(pd.source_to_listen_from_exists("list_from_pd").unwrap());
+    assert!(!pd
+        .source_to_listen_from_exists("endpoint_not_created")
+        .unwrap());
 
-    close_patch(patch_handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_after_touch.rs
+++ b/tests/send_and_receive_after_touch.rs
@@ -2,13 +2,7 @@
 
 use std::sync::{mpsc, Arc, Mutex};
 
-use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch, receive::on_midi_after_touch, send::send_after_touch,
-        util::dsp_on,
-    },
-    Pd,
-};
+use libpd_rs::{functions::block_size, Pd};
 
 #[test]
 fn send_and_receive_after_touch() {
@@ -17,17 +11,17 @@ fn send_and_receive_after_touch() {
 
     let after_touch_messages_received: Arc<Mutex<Vec<(i32, i32)>>> = Arc::new(Mutex::new(vec![]));
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
-
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let messages_to_fill = after_touch_messages_received.clone();
-    on_midi_after_touch(move |channel, value| {
+    pd.on_midi_after_touch(move |channel, value| {
         messages_to_fill.lock().unwrap().push((channel, value));
     });
+
+    pd.dsp_on().unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -61,7 +55,7 @@ fn send_and_receive_after_touch() {
     #[allow(clippy::explicit_counter_loop)]
     // Send 5 note on messages in sequence.
     for _ in 0..5 {
-        send_after_touch(channel, value).unwrap();
+        pd.send_after_touch(channel, value).unwrap();
         channel += 1;
         value += 1;
     }
@@ -86,5 +80,5 @@ fn send_and_receive_after_touch() {
             assert_eq!(p1, p2);
         });
 
-    close_patch(patch_handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_control_change.rs
+++ b/tests/send_and_receive_control_change.rs
@@ -2,13 +2,7 @@
 
 use std::sync::{mpsc, Arc, Mutex};
 
-use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch, receive::on_midi_control_change,
-        send::send_control_change, util::dsp_on,
-    },
-    Pd,
-};
+use libpd_rs::{functions::block_size, Pd};
 
 #[test]
 fn send_and_receive_control_change() {
@@ -18,20 +12,20 @@ fn send_and_receive_control_change() {
     let control_change_messages_received: Arc<Mutex<Vec<(i32, i32, i32)>>> =
         Arc::new(Mutex::new(vec![]));
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
-
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let messages_to_fill = control_change_messages_received.clone();
-    on_midi_control_change(move |channel, controller_number, value| {
+    pd.on_midi_control_change(move |channel, controller_number, value| {
         messages_to_fill
             .lock()
             .unwrap()
             .push((channel, controller_number, value));
     });
+
+    pd.dsp_on().unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -66,7 +60,8 @@ fn send_and_receive_control_change() {
     #[allow(clippy::explicit_counter_loop)]
     // Send 5 note on messages in sequence.
     for _ in 0..5 {
-        send_control_change(channel, controller_number, value).unwrap();
+        pd.send_control_change(channel, controller_number, value)
+            .unwrap();
         channel += 1;
         controller_number += 1;
         value += 1;
@@ -94,5 +89,5 @@ fn send_and_receive_control_change() {
             assert_eq!(v1, v2);
         });
 
-    close_patch(patch_handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_double.rs
+++ b/tests/send_and_receive_double.rs
@@ -2,15 +2,7 @@
 
 use std::sync::{mpsc, Arc, Mutex};
 
-use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch,
-        receive::{on_double, start_listening_from, stop_listening_from},
-        send::send_double_to,
-        util::dsp_on,
-    },
-    Pd,
-};
+use libpd_rs::{functions::block_size, Pd};
 
 #[test]
 fn send_and_receive_double() {
@@ -19,19 +11,20 @@ fn send_and_receive_double() {
 
     let floats: Arc<Mutex<Vec<f64>>> = Arc::new(Mutex::new(vec![]));
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
-
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let floats_to_fill = floats.clone();
-    on_double(move |source, value| {
+    pd.on_double(move |source, value| {
         assert_eq!(source, "float_from_pd");
         floats_to_fill.lock().unwrap().push(value);
-    });
-    let receiver_handle = start_listening_from("float_from_pd").unwrap();
+    })
+    .unwrap();
+
+    let receiver_handle = pd.start_listening_from("float_from_pd").unwrap();
+    pd.dsp_on().unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -62,11 +55,11 @@ fn send_and_receive_double() {
     let mut float: f64 = 1.0;
     // Send 5 floats in sequence.
     for _ in 0..5 {
-        send_double_to("float_from_rust", float).unwrap();
+        pd.send_double_to("float_from_rust", float).unwrap();
         float += 1.0;
     }
-    send_double_to("float_from_rust", f64::MAX).unwrap();
-    send_double_to("float_from_rust", f64::MIN).unwrap();
+    pd.send_double_to("float_from_rust", f64::MAX).unwrap();
+    pd.send_double_to("float_from_rust", f64::MIN).unwrap();
     std::thread::sleep(std::time::Duration::from_millis(50));
 
     // Stop pd.
@@ -87,6 +80,6 @@ fn send_and_receive_double() {
     assert_eq!(f64::MAX, floats.lock().unwrap()[5]);
     assert_eq!(f64::MIN, floats.lock().unwrap()[6]);
     // Stop listening and close handle.
-    stop_listening_from(receiver_handle);
-    close_patch(patch_handle).unwrap();
+    pd.stop_listening_from(receiver_handle);
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_midi_byte.rs
+++ b/tests/send_and_receive_midi_byte.rs
@@ -2,13 +2,7 @@
 
 use std::sync::{mpsc, Arc, Mutex};
 
-use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch, receive::on_midi_byte, send::send_midi_byte,
-        util::dsp_on,
-    },
-    Pd,
-};
+use libpd_rs::{functions::block_size, Pd};
 
 #[test]
 fn send_and_receive_midi_byte() {
@@ -17,17 +11,17 @@ fn send_and_receive_midi_byte() {
 
     let midi_byte_messages_received: Arc<Mutex<Vec<(i32, i32)>>> = Arc::new(Mutex::new(vec![]));
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
-
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let messages_to_fill = midi_byte_messages_received.clone();
-    on_midi_byte(move |port, byte| {
+    pd.on_midi_byte(move |port, byte| {
         messages_to_fill.lock().unwrap().push((port, byte));
     });
+
+    pd.dsp_on().unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -61,7 +55,7 @@ fn send_and_receive_midi_byte() {
     #[allow(clippy::explicit_counter_loop)]
     // Send 5 note on messages in sequence.
     for _ in 0..5 {
-        send_midi_byte(port, byte).unwrap();
+        pd.send_midi_byte(port, byte).unwrap();
         port += 1;
         byte += 0x10;
     }
@@ -85,5 +79,5 @@ fn send_and_receive_midi_byte() {
             assert_eq!(p1, p2);
         });
 
-    close_patch(patch_handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_pitch_bend.rs
+++ b/tests/send_and_receive_pitch_bend.rs
@@ -2,13 +2,7 @@
 
 use std::sync::{mpsc, Arc, Mutex};
 
-use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch, receive::on_midi_pitch_bend, send::send_pitch_bend,
-        util::dsp_on,
-    },
-    Pd,
-};
+use libpd_rs::{functions::block_size, Pd};
 
 #[test]
 fn send_and_receive_pitch_bend() {
@@ -17,20 +11,20 @@ fn send_and_receive_pitch_bend() {
 
     let pitch_bend_messages_received: Arc<Mutex<Vec<(i32, i32)>>> = Arc::new(Mutex::new(vec![]));
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
-
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let messages_to_fill = pitch_bend_messages_received.clone();
-    on_midi_pitch_bend(move |channel, bend_amount| {
+    pd.on_midi_pitch_bend(move |channel, bend_amount| {
         messages_to_fill
             .lock()
             .unwrap()
             .push((channel, bend_amount));
     });
+
+    pd.dsp_on().unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -64,7 +58,7 @@ fn send_and_receive_pitch_bend() {
     #[allow(clippy::explicit_counter_loop)]
     // Send 5 note on messages in sequence.
     for _ in 0..5 {
-        send_pitch_bend(channel, bend_amount).unwrap();
+        pd.send_pitch_bend(channel, bend_amount).unwrap();
         channel += 1;
         bend_amount += 1000;
     }
@@ -96,5 +90,5 @@ fn send_and_receive_pitch_bend() {
             assert_eq!(p1, p2);
         });
 
-    close_patch(patch_handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_sysex.rs
+++ b/tests/send_and_receive_sysex.rs
@@ -2,12 +2,7 @@
 
 use std::sync::{mpsc, Arc, Mutex};
 
-use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch, receive::on_midi_byte, send::send_sysex, util::dsp_on,
-    },
-    Pd,
-};
+use libpd_rs::{functions::block_size, Pd};
 
 #[test]
 fn send_and_receive_sysex() {
@@ -16,17 +11,17 @@ fn send_and_receive_sysex() {
 
     let sysex_messages_received: Arc<Mutex<Vec<(i32, i32)>>> = Arc::new(Mutex::new(vec![]));
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
-
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let messages_to_fill = sysex_messages_received.clone();
-    on_midi_byte(move |port, byte| {
+    pd.on_midi_byte(move |port, byte| {
         messages_to_fill.lock().unwrap().push((port, byte));
     });
+
+    pd.dsp_on().unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -60,7 +55,7 @@ fn send_and_receive_sysex() {
     #[allow(clippy::explicit_counter_loop)]
     // Send 5 note on messages in sequence.
     for _ in 0..5 {
-        send_sysex(port, byte).unwrap();
+        pd.send_sysex(port, byte).unwrap();
         port += 1;
         byte += 0x10;
     }
@@ -84,5 +79,5 @@ fn send_and_receive_sysex() {
             assert_eq!(p1, p2);
         });
 
-    close_patch(patch_handle).unwrap();
+    pd.close_patch().unwrap();
 }

--- a/tests/send_and_receive_typed_message.rs
+++ b/tests/send_and_receive_typed_message.rs
@@ -3,13 +3,7 @@
 use std::sync::{mpsc, Arc, Mutex};
 
 use libpd_rs::{
-    functions::{
-        block_size, close_patch, open_patch,
-        receive::{on_message, start_listening_from, stop_listening_from},
-        send::{finish_message_as_typed_message_and_send_to, send_message_to, start_message},
-        util::dsp_on,
-        verbose_print_state,
-    },
+    functions::{block_size, verbose_print_state},
     Pd,
 };
 
@@ -18,23 +12,24 @@ fn send_and_receive_typed_message() {
     let sample_rate = 44100;
     let output_channels = 2;
 
-    let pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
+    let mut pd = Pd::init_and_configure(0, output_channels, sample_rate).unwrap();
     let ctx = pd.audio_context();
 
-    dsp_on().unwrap();
+    pd.dsp_on().unwrap();
 
     verbose_print_state(true);
 
-    let patch_handle = open_patch("tests/patches/echo.pd").unwrap();
+    pd.open_patch("tests/patches/echo.pd").unwrap();
 
     let message_count = Arc::new(Mutex::new(0));
     let mc = message_count.clone();
-    on_message(move |source, selector, _list| {
+    pd.on_message(move |source, selector, _list| {
         assert_eq!(source, "pd");
         assert_eq!(selector, "audiostatus");
         *mc.lock().unwrap() += 1;
-    });
-    let receiver_handle = start_listening_from("pd").unwrap();
+    })
+    .unwrap();
+    let receiver_handle = pd.start_listening_from("pd").unwrap();
 
     let (tx, rx) = mpsc::channel::<()>();
 
@@ -62,10 +57,11 @@ fn send_and_receive_typed_message() {
         }
     });
 
-    start_message(0).unwrap();
-    finish_message_as_typed_message_and_send_to("pd", "audiostatus").unwrap();
+    pd.start_message(0).unwrap();
+    pd.finish_message_as_typed_message_and_send_to("pd", "audiostatus")
+        .unwrap();
 
-    send_message_to("pd", "audiostatus", &[]).unwrap();
+    pd.send_message_to("pd", "audiostatus", &[]).unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
@@ -75,6 +71,6 @@ fn send_and_receive_typed_message() {
     handle.join().unwrap();
 
     // Stop listening and close handle.
-    stop_listening_from(receiver_handle);
-    close_patch(patch_handle).unwrap();
+    pd.stop_listening_from(receiver_handle);
+    pd.close_patch().unwrap();
 }


### PR DESCRIPTION
As of current if you try to call almost any function in `libpd_rs::functions` from a different thread than the context was created, it will segfault, this of course makes perfect sense given that each context is thread-specific but it is my opinion that behavior should not be able to happen in the first place. This pull request extends the `Pd` struct to include all the functions in `libpd_rs::functions::send` and `libpd_rs::functions::recieve`.

By calling these from the `Pd` struct it becomes impossible to use these functions from a separate thread since `Pd` is not `Send` or `Sync`. I also place `ActiveInstanceGuard`s on each invocation of the functions to ensure that the correct instance is used, although I haven't tested whether or not having multiple instances running on the same thread works, I assume it's not worse than it was when I started.

Additionally, runtime checks for the invariants of buffer overflows and not adding to messages that haven't yet been started yet have been added for `start_message`, `add_x_to_started_message`, `finish_message_as_list_and_send_to` and `finish_message_as_typed_message_and_send_to`.

I also ensure that when the Pd instance is dropped, the supplied callbacks for event listeners are properly cleaned up instead of leaking the memory. I achieve this with a somewhat-hacky but performant internal type called `Callbacks` which manages a Vec of destructors to call when Pd drops. Perhaps it would be better to drop the callbacks when they are replaced rather than dropping them at the end of the lifetime of the Pd instance but it's still much better than it was before, where callbacks simply leaked memory for the duration of the running program. In the end my changes add a few bytes to the size of the `Pd` struct for the cost of dramatically improved safety.

This PR updates all the tests to use the new Pd struct API rather than old `libpd_rs::functions` one because I believe that this really should be the correct way to use it. As of now I have implemented these changes to be in what I believe to be mostly non-breaking. However I believe if you were to go make breaking changes I think that almost every function if not every function in `libpd_rs::functions` be marked as unsafe, since they are able to segfault.

The last thing I did was add a check in the callback registration about registering callbacks while the DSP is active. The docs say not to but the tests all do this. I've rearranged most of the tests around to avoid this except the `send_and_receive_typed_message` test which I can't do this because otherwise a `dsp` message is sent to the `on_message` test. I could fix this, but I figured that I should probably just ask what the documentation note "`Note: Do not register this listener while pd DSP is running.`" is actually for, since the examples seem to work anyway. The check is currently disabled behind a flag called `GUARD_FROM_CALLBACK_DURING_DSP`. Enable it if you would like or remove the check if you think it is unnecessary. 

This change might be a bit opinionated but when loading libpd it spews a bunch of version info out to stderr which is really unbecoming of a library and very annoying, I couldn't work out how to shut it up using calls to the C API so I've shut it up with the nifty [gag](https://docs.rs/gag/latest/gag/) crate. This makes the tests way less noisy and hopefully results in a better experience for everyone using the library, although it does suppress potentially useful debug information, so I certainly understand wanting to revert this change.

These changes are clippy passing and the docs compile nicely without errors too. I hope these changes are useful to you!